### PR TITLE
Use locally installed version of jspm 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 
 before_script:
 - sleep 5
-- npm install -g gulp jspm pm2 jasmine
+- npm install -g gulp jasmine
 
 script:
 - source run-tests.sh

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,7 @@
     "gulp-sourcemaps": "latest",
     "gulp-tslint": "latest",
     "gulp-uglify": "latest",
+    "jspm": "^0.16.35",
     "main-bower-files": "latest",
     "merge2": "latest",
     "phantomjs-prebuilt": "latest",

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -21,8 +21,9 @@ echo $RAM_CONF
 cd frontend
 npm install
 node_modules/.bin/typings install
-jspm cc
-jspm install -y
+node_modules/.bin/jspm -v
+node_modules/.bin/jspm cc
+node_modules/.bin/jspm install -y
 
 cd ../backend
 npm install


### PR DESCRIPTION
This will ensure upgrades to the global jspm will not alter the behavior of the application as per recommendation from the JSPM website.