### PR TITLE
Added first cut of shared secret and shared secret type

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {},
   "dependencies": {
+    "bcrypt": "^0.8.6",
     "body-parser": "^1.15.0",
     "debug": "^2.2.0",
     "express": "^4.13.4",

--- a/backend/typescript/models/base.ts
+++ b/backend/typescript/models/base.ts
@@ -4,6 +4,33 @@ import * as mongoose from 'mongoose';
 /* tslint:disable:no-var-requires */ const mongooseIdValidator = require('mongoose-id-validator');
 /* tslint:disable:no-var-requires */ const mongooseDeepPopulate = require('mongoose-deep-populate')(mongoose);
 
+/* RAMEnum is a simple class construct that represents a enumerated type so we can work with classes not strings.
+ */
+export class RAMEnum {
+
+    protected static AllValues: RAMEnum[];
+
+    public static values<T extends RAMEnum>():T[] {
+        return this.AllValues as T[];
+    }
+
+    public static valueStrings<T extends RAMEnum>():String[] {
+        return this.AllValues.map((value:T) => value.name);
+    }
+
+    public static valueOf<T extends RAMEnum>(name:String):T {
+        for (let type of this.AllValues) {
+            if ((type as T).name === name) {
+                return type as T;
+            }
+        }
+        return null;
+    }
+
+    constructor(public name:String) {
+    }
+}
+
 /* A RAMObject defines the common attributes that all objects in the RAM
  * model will contain.
  * Most objects in RAM extend off the RAMObject

--- a/backend/typescript/models/identity.model.ts
+++ b/backend/typescript/models/identity.model.ts
@@ -204,8 +204,8 @@ export interface IIdentity extends IRAMObject {
     defaultInd: boolean;
     agencyToken: string;
     invitationCodeStatus: string;
-    invitationCodeExpiryTimestamp: date;
-    invitationCodeClaimedTimestamp: date;
+    invitationCodeExpiryTimestamp: Date;
+    invitationCodeClaimedTimestamp: Date;
     invitationCodeTemporaryEmailAddress: string;
     publicIdentifierScheme: string;
     linkIdScheme: string;

--- a/backend/typescript/models/identity.model.ts
+++ b/backend/typescript/models/identity.model.ts
@@ -11,12 +11,14 @@ const _ProfileModel = ProfileModel;
 
 export class IdentityType {
 
-    public static ProvidedToken = new IdentityType('AGENCY_PROVIDED_TOKEN');
+    public static AgencyProvidedToken = new IdentityType('AGENCY_PROVIDED_TOKEN');
+    public static InvitationCode = new IdentityType('INVITATION_CODE');
     public static PublicIdentifier = new IdentityType('PUBLIC_IDENTIFIER');
     public static LinkId = new IdentityType('LINK_ID');
 
     public static AllValues = [
-        IdentityType.ProvidedToken,
+        IdentityType.AgencyProvidedToken,
+        IdentityType.InvitationCode,
         IdentityType.PublicIdentifier,
         IdentityType.LinkId
     ];
@@ -31,6 +33,99 @@ export class IdentityType {
 
     public static valueOf(name:String):IdentityType {
         for (let type of IdentityType.AllValues) {
+            if (type.name === name) {
+                return type;
+            }
+        }
+        return null;
+    }
+
+    constructor(public name:String) {
+    }
+}
+
+export class IdentityInvitationCodeStatus {
+
+    public static Pending = new IdentityInvitationCodeStatus('PENDING');
+    public static Claimed = new IdentityInvitationCodeStatus('CLAIMED');
+
+    public static AllValues = [
+        IdentityInvitationCodeStatus.Pending,
+        IdentityInvitationCodeStatus.Claimed
+    ];
+
+    public static values():IdentityInvitationCodeStatus[] {
+        return IdentityInvitationCodeStatus.AllValues;
+    }
+
+    public static valueStrings():String[] {
+        return IdentityInvitationCodeStatus.AllValues.map((value) => value.name);
+    }
+
+    public static valueOf(name:String):IdentityInvitationCodeStatus {
+        for (let type of IdentityInvitationCodeStatus.AllValues) {
+            if (type.name === name) {
+                return type;
+            }
+        }
+        return null;
+    }
+
+    constructor(public name:String) {
+    }
+}
+
+export class IdentityPublicIdentifierScheme {
+
+    public static ABN = new IdentityPublicIdentifierScheme('ABN');
+
+    public static AllValues = [
+        IdentityPublicIdentifierScheme.ABN
+    ];
+
+    public static values():IdentityPublicIdentifierScheme[] {
+        return IdentityPublicIdentifierScheme.AllValues;
+    }
+
+    public static valueStrings():String[] {
+        return IdentityPublicIdentifierScheme.AllValues.map((value) => value.name);
+    }
+
+    public static valueOf(name:String):IdentityPublicIdentifierScheme {
+        for (let type of IdentityPublicIdentifierScheme.AllValues) {
+            if (type.name === name) {
+                return type;
+            }
+        }
+        return null;
+    }
+
+    constructor(public name:String) {
+    }
+}
+
+export class IdentityLinkIdScheme {
+
+    public static MyGov = new IdentityPublicIdentifierScheme('MY_GOV');
+    public static Vanguard = new IdentityPublicIdentifierScheme('VANGUARD');
+    public static AuthenticatorApp = new IdentityPublicIdentifierScheme('AUTHENTICATOR_APP');
+
+    public static AllValues = [
+        IdentityLinkIdScheme.MyGov,
+        IdentityLinkIdScheme.Vanguard,
+        IdentityLinkIdScheme.AuthenticatorApp
+    ];
+
+    public static values():IdentityLinkIdScheme[] {
+        return IdentityLinkIdScheme.AllValues;
+    }
+
+    public static valueStrings():String[] {
+        return IdentityLinkIdScheme.AllValues.map((value) => value.name);
+    }
+
+    public static valueOf(name:String):IdentityLinkIdScheme {
+        for (let type of IdentityLinkIdScheme.AllValues) {
             if (type.name === name) {
                 return type;
             }
@@ -61,15 +156,36 @@ const IdentitySchema = RAMSchema({
         required: [true, 'Default Indicator is required'],
         default: false
     },
-    token: {
+    agencyToken: {
         type: String,
         trim: true
     },
-    scheme: {
+    invitationCodeStatus: {
+        type: String,
+        trim: true,
+        enum: IdentityInvitationCodeStatus.valueStrings()
+    },
+    invitationCodeExpiryTimestamp: {
+        type: Date
+    },
+    invitationCodeClaimedTimestamp: {
+        type: Date
+    },
+    invitationCodeTemporaryEmailAddress: {
         type: String,
         trim: true
     },
-    consumer: {
+    publicIdentifierScheme: {
+        type: String,
+        trim: true,
+        enum: IdentityPublicIdentifierScheme.valueStrings()
+    },
+    linkIdScheme: {
+        type: String,
+        trim: true,
+        enum: IdentityLinkIdScheme.valueStrings()
+    },
+    linkIdConsumer: {
         type: String,
         trim: true
     },
@@ -86,11 +202,19 @@ export interface IIdentity extends IRAMObject {
     idValue: string;
     identityType: string;
     defaultInd: boolean;
-    token: string;
-    scheme: string;
-    consumer: string;
+    agencyToken: string;
+    invitationCodeStatus: string;
+    invitationCodeExpiryTimestamp: date;
+    invitationCodeClaimedTimestamp: date;
+    invitationCodeTemporaryEmailAddress: string;
+    publicIdentifierScheme: string;
+    linkIdScheme: string;
+    linkIdConsumer: string;
     profile: IProfile;
     identityTypeEnum(): IdentityType;
+    invitationCodeStatusEnum(): IdentityInvitationCodeStatus;
+    publicIdentifierSchemeEnum(): IdentityPublicIdentifierScheme;
+    linkIdSchemeEnum(): IdentityLinkIdScheme;
 }
 
 export interface IIdentityModel extends mongoose.Model<IIdentity> {
@@ -101,6 +225,18 @@ export interface IIdentityModel extends mongoose.Model<IIdentity> {
 
 IdentitySchema.method('identityTypeEnum', function () {
     return IdentityType.valueOf(this.identityType);
+});
+
+IdentitySchema.method('invitationCodeStatusEnum', function () {
+    return IdentityInvitationCodeStatus.valueOf(this.invitationCodeStatus);
+});
+
+IdentitySchema.method('publicIdentifierSchemeEnum', function () {
+    return IdentityPublicIdentifierScheme.valueOf(this.publicIdentifierScheme);
+});
+
+IdentitySchema.method('linkIdSchemeEnum', function () {
+    return IdentityLinkIdScheme.valueOf(this.linkIdScheme);
 });
 
 // static methods .....................................................................................................

--- a/backend/typescript/models/identity.model.ts
+++ b/backend/typescript/models/identity.model.ts
@@ -13,14 +13,14 @@ export class IdentityType {
 
     public static AgencyProvidedToken = new IdentityType('AGENCY_PROVIDED_TOKEN');
     public static InvitationCode = new IdentityType('INVITATION_CODE');
-    public static PublicIdentifier = new IdentityType('PUBLIC_IDENTIFIER');
     public static LinkId = new IdentityType('LINK_ID');
+    public static PublicIdentifier = new IdentityType('PUBLIC_IDENTIFIER');
 
     public static AllValues = [
         IdentityType.AgencyProvidedToken,
         IdentityType.InvitationCode,
-        IdentityType.PublicIdentifier,
-        IdentityType.LinkId
+        IdentityType.LinkId,
+        IdentityType.PublicIdentifier
     ];
 
     public static values():IdentityType[] {
@@ -46,12 +46,12 @@ export class IdentityType {
 
 export class IdentityInvitationCodeStatus {
 
-    public static Pending = new IdentityInvitationCodeStatus('PENDING');
     public static Claimed = new IdentityInvitationCodeStatus('CLAIMED');
+    public static Pending = new IdentityInvitationCodeStatus('PENDING');
 
     public static AllValues = [
-        IdentityInvitationCodeStatus.Pending,
-        IdentityInvitationCodeStatus.Claimed
+        IdentityInvitationCodeStatus.Claimed,
+        IdentityInvitationCodeStatus.Pending
     ];
 
     public static values():IdentityInvitationCodeStatus[] {
@@ -106,14 +106,14 @@ export class IdentityPublicIdentifierScheme {
 
 export class IdentityLinkIdScheme {
 
+    public static AuthenticatorApp = new IdentityPublicIdentifierScheme('AUTHENTICATOR_APP');
     public static MyGov = new IdentityPublicIdentifierScheme('MY_GOV');
     public static Vanguard = new IdentityPublicIdentifierScheme('VANGUARD');
-    public static AuthenticatorApp = new IdentityPublicIdentifierScheme('AUTHENTICATOR_APP');
 
     public static AllValues = [
+        IdentityLinkIdScheme.AuthenticatorApp,
         IdentityLinkIdScheme.MyGov,
-        IdentityLinkIdScheme.Vanguard,
-        IdentityLinkIdScheme.AuthenticatorApp
+        IdentityLinkIdScheme.Vanguard
     ];
 
     public static values():IdentityLinkIdScheme[] {

--- a/backend/typescript/models/identity.model.ts
+++ b/backend/typescript/models/identity.model.ts
@@ -1,5 +1,5 @@
 import * as mongoose from 'mongoose';
-import {IRAMObject, RAMSchema} from './base';
+import {RAMEnum, IRAMObject, RAMSchema} from './base';
 import {IProfile, ProfileModel} from './profile.model';
 
 // force schema to load first (see https://github.com/atogov/RAM/pull/220#discussion_r65115456)
@@ -9,131 +9,67 @@ const _ProfileModel = ProfileModel;
 
 // enums, utilities, helpers ..........................................................................................
 
-export class IdentityType {
+export class IdentityType extends RAMEnum {
 
     public static AgencyProvidedToken = new IdentityType('AGENCY_PROVIDED_TOKEN');
     public static InvitationCode = new IdentityType('INVITATION_CODE');
     public static LinkId = new IdentityType('LINK_ID');
     public static PublicIdentifier = new IdentityType('PUBLIC_IDENTIFIER');
 
-    public static AllValues = [
+    protected static AllValues = [
         IdentityType.AgencyProvidedToken,
         IdentityType.InvitationCode,
         IdentityType.LinkId,
         IdentityType.PublicIdentifier
     ];
 
-    public static values():IdentityType[] {
-        return IdentityType.AllValues;
-    }
-
-    public static valueStrings():String[] {
-        return IdentityType.AllValues.map((value) => value.name);
-    }
-
-    public static valueOf(name:String):IdentityType {
-        for (let type of IdentityType.AllValues) {
-            if (type.name === name) {
-                return type;
-            }
-        }
-        return null;
-    }
-
-    constructor(public name:String) {
+    constructor(name:String) {
+        super(name);
     }
 }
 
-export class IdentityInvitationCodeStatus {
+export class IdentityInvitationCodeStatus extends RAMEnum {
 
     public static Claimed = new IdentityInvitationCodeStatus('CLAIMED');
     public static Pending = new IdentityInvitationCodeStatus('PENDING');
 
-    public static AllValues = [
+    protected static AllValues = [
         IdentityInvitationCodeStatus.Claimed,
         IdentityInvitationCodeStatus.Pending
     ];
 
-    public static values():IdentityInvitationCodeStatus[] {
-        return IdentityInvitationCodeStatus.AllValues;
-    }
-
-    public static valueStrings():String[] {
-        return IdentityInvitationCodeStatus.AllValues.map((value) => value.name);
-    }
-
-    public static valueOf(name:String):IdentityInvitationCodeStatus {
-        for (let type of IdentityInvitationCodeStatus.AllValues) {
-            if (type.name === name) {
-                return type;
-            }
-        }
-        return null;
-    }
-
-    constructor(public name:String) {
+    constructor(name:String) {
+        super(name);
     }
 }
 
-export class IdentityPublicIdentifierScheme {
+export class IdentityPublicIdentifierScheme extends RAMEnum {
 
     public static ABN = new IdentityPublicIdentifierScheme('ABN');
 
-    public static AllValues = [
+    protected static AllValues = [
         IdentityPublicIdentifierScheme.ABN
     ];
 
-    public static values():IdentityPublicIdentifierScheme[] {
-        return IdentityPublicIdentifierScheme.AllValues;
-    }
-
-    public static valueStrings():String[] {
-        return IdentityPublicIdentifierScheme.AllValues.map((value) => value.name);
-    }
-
-    public static valueOf(name:String):IdentityPublicIdentifierScheme {
-        for (let type of IdentityPublicIdentifierScheme.AllValues) {
-            if (type.name === name) {
-                return type;
-            }
-        }
-        return null;
-    }
-
-    constructor(public name:String) {
+    constructor(name:String) {
+        super(name);
     }
 }
 
-export class IdentityLinkIdScheme {
+export class IdentityLinkIdScheme extends RAMEnum {
 
     public static AuthenticatorApp = new IdentityPublicIdentifierScheme('AUTHENTICATOR_APP');
     public static MyGov = new IdentityPublicIdentifierScheme('MY_GOV');
     public static Vanguard = new IdentityPublicIdentifierScheme('VANGUARD');
 
-    public static AllValues = [
+    protected static AllValues = [
         IdentityLinkIdScheme.AuthenticatorApp,
         IdentityLinkIdScheme.MyGov,
         IdentityLinkIdScheme.Vanguard
     ];
 
-    public static values():IdentityLinkIdScheme[] {
-        return IdentityLinkIdScheme.AllValues;
-    }
-
-    public static valueStrings():String[] {
-        return IdentityLinkIdScheme.AllValues.map((value) => value.name);
-    }
-
-    public static valueOf(name:String):IdentityLinkIdScheme {
-        for (let type of IdentityLinkIdScheme.AllValues) {
-            if (type.name === name) {
-                return type;
-            }
-        }
-        return null;
-    }
-
-    constructor(public name:String) {
+    constructor(name:String) {
+        super(name);
     }
 }
 

--- a/backend/typescript/models/identity.model.ts
+++ b/backend/typescript/models/identity.model.ts
@@ -112,7 +112,8 @@ IdentitySchema.static('findByIdValueAndType', (idValue:String, type:IdentityType
             identityType: type.name
         })
         .deepPopulate([
-            'profile.name'
+            'profile.name',
+            'profile.sharedSecrets.sharedSecretType'
         ])
         .exec();
 });

--- a/backend/typescript/models/profile.model.ts
+++ b/backend/typescript/models/profile.model.ts
@@ -1,5 +1,5 @@
 import * as mongoose from 'mongoose';
-import {IRAMObject, RAMSchema} from './base';
+import {RAMEnum, IRAMObject, RAMSchema} from './base';
 import {IName, NameModel} from './name.model';
 import {ISharedSecret, SharedSecretModel} from './sharedSecret.model';
 
@@ -13,38 +13,22 @@ const _SharedSecretModel = SharedSecretModel;
 
 // enums, utilities, helpers ..........................................................................................
 
-export class ProfileProvider {
+export class ProfileProvider extends RAMEnum {
 
     public static AuthenticatorApp = new ProfileProvider('AUTHENTICATOR_APP');
     public static MyGov = new ProfileProvider('MY_GOV');
     public static SelfAsserted = new ProfileProvider('SELF_ASSERTED');
     public static Vanguard = new ProfileProvider('VANGUARD');
 
-    public static AllValues = [
+    protected static AllValues = [
         ProfileProvider.AuthenticatorApp,
         ProfileProvider.MyGov,
         ProfileProvider.SelfAsserted,
         ProfileProvider.Vanguard
     ];
 
-    public static values():ProfileProvider[] {
-        return ProfileProvider.AllValues;
-    }
-
-    public static valueStrings():String[] {
-        return ProfileProvider.AllValues.map((value) => value.name);
-    }
-
-    public static valueOf(name:String):ProfileProvider {
-        for (let type of ProfileProvider.AllValues) {
-            if (type.name === name) {
-                return type;
-            }
-        }
-        return null;
-    }
-
     constructor(public name:String) {
+        super(name);
     }
 }
 

--- a/backend/typescript/models/profile.model.ts
+++ b/backend/typescript/models/profile.model.ts
@@ -69,6 +69,7 @@ export interface IProfile extends IRAMObject {
     name: IName;
     sharedSecrets: [ISharedSecret];
     providerEnum(): ProfileProvider;
+    getSharedSecret(code:String): ISharedSecret;
 }
 
 /* tslint:disable:no-empty-interfaces */
@@ -79,6 +80,17 @@ export interface IProfileModel extends mongoose.Model<IProfile> {
 
 ProfileSchema.method('providerEnum', function () {
     return ProfileProvider.valueOf(this.provider);
+});
+
+ProfileSchema.method('getSharedSecret', function (code:String) {
+    if (code && this.sharedSecrets) {
+        for (let sharedSecret of this.sharedSecrets) {
+            if (sharedSecret.sharedSecretType.code === code) {
+                return sharedSecret;
+            }
+        }
+    }
+    return null;
 });
 
 // static methods .....................................................................................................

--- a/backend/typescript/models/profile.model.ts
+++ b/backend/typescript/models/profile.model.ts
@@ -1,11 +1,15 @@
 import * as mongoose from 'mongoose';
 import {IRAMObject, RAMSchema} from './base';
 import {IName, NameModel} from './name.model';
+import {ISharedSecret, SharedSecretModel} from './sharedSecret.model';
 
 // force schema to load first (see https://github.com/atogov/RAM/pull/220#discussion_r65115456)
 
 /* tslint:disable:no-unused-variable */
 const _NameModel = NameModel;
+
+/* tslint:disable:no-unused-variable */
+const _SharedSecretModel = SharedSecretModel;
 
 // enums, utilities, helpers ..........................................................................................
 
@@ -51,7 +55,11 @@ const ProfileSchema = RAMSchema({
         type: mongoose.Schema.Types.ObjectId,
         ref: 'Name',
         required: [true, 'Name is required']
-    }
+    },
+    sharedSecrets: [{
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'SharedSecret'
+    }]
 });
 
 // interfaces .........................................................................................................
@@ -59,6 +67,7 @@ const ProfileSchema = RAMSchema({
 export interface IProfile extends IRAMObject {
     provider: string;
     name: IName;
+    sharedSecrets: [ISharedSecret];
     providerEnum(): ProfileProvider;
 }
 

--- a/backend/typescript/models/profile.model.ts
+++ b/backend/typescript/models/profile.model.ts
@@ -15,10 +15,16 @@ const _SharedSecretModel = SharedSecretModel;
 
 export class ProfileProvider {
 
+    public static AuthenticatorApp = new ProfileProvider('AUTHENTICATOR_APP');
     public static MyGov = new ProfileProvider('MY_GOV');
+    public static SelfAsserted = new ProfileProvider('SELF_ASSERTED');
+    public static Vanguard = new ProfileProvider('VANGUARD');
 
     public static AllValues = [
-        ProfileProvider.MyGov
+        ProfileProvider.AuthenticatorApp,
+        ProfileProvider.MyGov,
+        ProfileProvider.SelfAsserted,
+        ProfileProvider.Vanguard
     ];
 
     public static values():ProfileProvider[] {

--- a/backend/typescript/models/relationshipAttributeName.model.ts
+++ b/backend/typescript/models/relationshipAttributeName.model.ts
@@ -61,10 +61,10 @@ export interface IRelationshipAttributeName extends ICodeDecode {
 }
 
 export interface IRelationshipAttributeNameModel extends mongoose.Model<IRelationshipAttributeName> {
-    findByCodeIgnoringDateRange: (id:String) => mongoose.Promise<IRelationshipAttributeName>;
-    findByCodeInDateRange: (id:String) => mongoose.Promise<IRelationshipAttributeName>;
+    findByCodeIgnoringDateRange: (code:String) => mongoose.Promise<IRelationshipAttributeName>;
+    findByCodeInDateRange: (code:String, date:Date) => mongoose.Promise<IRelationshipAttributeName>;
     listIgnoringDateRange: () => mongoose.Promise<IRelationshipAttributeName[]>;
-    listInDateRange: () => mongoose.Promise<IRelationshipAttributeName[]>;
+    listInDateRange: (date:Date) => mongoose.Promise<IRelationshipAttributeName[]>;
 }
 
 // instance methods ...................................................................................................
@@ -103,12 +103,12 @@ RelationshipAttributeNameSchema.static('findByCodeIgnoringDateRange', (code:Stri
         .exec();
 });
 
-RelationshipAttributeNameSchema.static('findByCodeInDateRange', (code:String) => {
+RelationshipAttributeNameSchema.static('findByCodeInDateRange', (code:String, date:Date) => {
     return this.RelationshipAttributeNameModel
         .findOne({
             code: code,
-            startDate: {$lte: new Date()},
-            $or: [{endDate: null}, {endDate: {$gt: new Date()}}]
+            startDate: {$lte: date},
+            $or: [{endDate: null}, {endDate: {$gte: date}}]
         })
         .exec();
 });
@@ -124,11 +124,11 @@ RelationshipAttributeNameSchema.static('listIgnoringDateRange', () => {
         .exec();
 });
 
-RelationshipAttributeNameSchema.static('listInDateRange', () => {
+RelationshipAttributeNameSchema.static('listInDateRange', (date:Date) => {
     return this.RelationshipAttributeNameModel
         .find({
-            startDate: {$lte: new Date()},
-            $or: [{endDate: null}, {endDate: {$gt: new Date()}}]
+            startDate: {$lte: date},
+            $or: [{endDate: null}, {endDate: {$gte: date}}]
         })
         .deepPopulate([
             'attributeNameUsages.attributeName'

--- a/backend/typescript/models/relationshipAttributeName.model.ts
+++ b/backend/typescript/models/relationshipAttributeName.model.ts
@@ -1,11 +1,11 @@
 import * as mongoose from 'mongoose';
-import {ICodeDecode, CodeDecodeSchema} from './base';
+import {RAMEnum, ICodeDecode, CodeDecodeSchema} from './base';
 import {HrefValue, RelationshipAttributeName as DTO} from '../../../commons/RamAPI';
 
 // enums, utilities, helpers ..........................................................................................
 
 // see https://github.com/atogov/RAM/wiki/Relationship-Attribute-Types
-export class RelationshipAttributeNameDomain {
+export class RelationshipAttributeNameDomain extends RAMEnum {
 
     public static Null = new RelationshipAttributeNameDomain('NULL');
     public static Boolean = new RelationshipAttributeNameDomain('BOOLEAN');
@@ -15,7 +15,7 @@ export class RelationshipAttributeNameDomain {
     public static SelectSingle = new RelationshipAttributeNameDomain('SELECT_SINGLE');
     public static SelectMulti = new RelationshipAttributeNameDomain('SELECT_MULTI');
 
-    public static AllValues = [
+    protected static AllValues = [
         RelationshipAttributeNameDomain.Null,
         RelationshipAttributeNameDomain.Boolean,
         RelationshipAttributeNameDomain.Number,
@@ -25,24 +25,8 @@ export class RelationshipAttributeNameDomain {
         RelationshipAttributeNameDomain.SelectMulti
     ];
 
-    public static values():RelationshipAttributeNameDomain[] {
-        return RelationshipAttributeNameDomain.AllValues;
-    }
-
-    public static valueOf(name:String):RelationshipAttributeNameDomain {
-        for (let type of RelationshipAttributeNameDomain.AllValues) {
-            if (type.name === name) {
-                return type;
-            }
-        }
-        return null;
-    }
-
-    public static valueStrings():String[] {
-        return RelationshipAttributeNameDomain.AllValues.map((value) => value.name);
-    }
-
-    constructor(public name:String) {
+    constructor(name:String) {
+        super(name);
     }
 }
 

--- a/backend/typescript/models/relationshipAttributeNameUsage.model.ts
+++ b/backend/typescript/models/relationshipAttributeNameUsage.model.ts
@@ -6,11 +6,9 @@ import {IRelationshipAttributeName, RelationshipAttributeNameModel} from './rela
 /* tslint:disable:no-unused-variable */
 const _RelationshipAttributeNameModel = RelationshipAttributeNameModel;
 
-export interface IRelationshipAttributeNameUsage extends mongoose.Document {
-    optionalInd: boolean;
-    defaultValue: string;
-    attributeName: IRelationshipAttributeName;
-}
+// enums, utilities, helpers ..........................................................................................
+
+// schema .............................................................................................................
 
 const RelationshipAttributeNameUsageSchema = new mongoose.Schema({
     optionalInd: {
@@ -29,9 +27,19 @@ const RelationshipAttributeNameUsageSchema = new mongoose.Schema({
     }
 });
 
+// interfaces .........................................................................................................
+
+export interface IRelationshipAttributeNameUsage extends mongoose.Document {
+    optionalInd: boolean;
+    defaultValue: string;
+    attributeName: IRelationshipAttributeName;
+}
+
 /* tslint:disable:no-empty-interfaces */
 export interface IRelationshipAttributeNameUsageModel extends mongoose.Model<IRelationshipAttributeNameUsage> {
 }
+
+// concrete model .....................................................................................................
 
 export const RelationshipAttributeNameUsageModel = mongoose.model(
     'RelationshipAttributeNameUsage',

--- a/backend/typescript/models/relationshipType.model.ts
+++ b/backend/typescript/models/relationshipType.model.ts
@@ -42,10 +42,10 @@ export interface IRelationshipType extends ICodeDecode {
 }
 
 export interface IRelationshipTypeModel extends mongoose.Model<IRelationshipType> {
-    findByCodeIgnoringDateRange: (id:String) => mongoose.Promise<IRelationshipType>;
-    findByCodeInDateRange: (id:String) => mongoose.Promise<IRelationshipType>;
+    findByCodeIgnoringDateRange: (code:String) => mongoose.Promise<IRelationshipType>;
+    findByCodeInDateRange: (code:String, date:Date) => mongoose.Promise<IRelationshipType>;
     listIgnoringDateRange: () => mongoose.Promise<IRelationshipType[]>;
-    listInDateRange: () => mongoose.Promise<IRelationshipType[]>;
+    listInDateRange: (date:Date) => mongoose.Promise<IRelationshipType[]>;
 }
 
 // static methods .....................................................................................................
@@ -61,12 +61,12 @@ RelationshipTypeSchema.static('findByCodeIgnoringDateRange', (code:String) => {
         .exec();
 });
 
-RelationshipTypeSchema.static('findByCodeInDateRange', (code:String) => {
+RelationshipTypeSchema.static('findByCodeInDateRange', (code:String, date:Date) => {
     return this.RelationshipTypeModel
         .findOne({
             code: code,
-            startDate: {$lte: new Date()},
-            $or: [{endDate: null}, {endDate: {$gt: new Date()}}]
+            startDate: {$lte: date},
+            $or: [{endDate: null}, {endDate: {$gte: date}}]
         })
         .deepPopulate([
             'attributeNameUsages.attributeName'
@@ -85,11 +85,11 @@ RelationshipTypeSchema.static('listIgnoringDateRange', () => {
         .exec();
 });
 
-RelationshipTypeSchema.static('listInDateRange', () => {
+RelationshipTypeSchema.static('listInDateRange', (date:Date) => {
     return this.RelationshipTypeModel
         .find({
-            startDate: {$lte: new Date()},
-            $or: [{endDate: null}, {endDate: {$gt: new Date()}}]
+            startDate: {$lte: date},
+            $or: [{endDate: null}, {endDate: {$gte: date}}]
         })
         .deepPopulate([
             'attributeNameUsages.attributeName'

--- a/backend/typescript/models/sharedSecret.model.ts
+++ b/backend/typescript/models/sharedSecret.model.ts
@@ -1,0 +1,46 @@
+import * as mongoose from 'mongoose';
+import {IRAMObject, RAMSchema} from './base';
+import {ISharedSecretType, SharedSecretTypeModel} from './sharedSecretType.model';
+
+// force schema to load first (see https://github.com/atogov/RAM/pull/220#discussion_r65115456)
+
+/* tslint:disable:no-unused-variable */
+const _SharedSecretTypeModel = SharedSecretTypeModel;
+
+// enums, utilities, helpers ..........................................................................................
+
+// schema .............................................................................................................
+
+const SharedSecretSchema = RAMSchema({
+    value: {
+        type: String,
+        required: [true, 'Value is required'],
+        trim: true
+    },
+    sharedSecretType: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'SharedSecretType',
+        required: [true, 'Type is required']
+    }
+});
+
+// interfaces .........................................................................................................
+
+export interface ISharedSecret extends IRAMObject {
+    value: string;
+    sharedSecretType: ISharedSecretType;
+}
+
+/* tslint:disable:no-empty-interfaces */
+export interface ISharedSecretModel extends mongoose.Model<ISharedSecret> {
+}
+
+// instance methods ...................................................................................................
+
+// static methods .....................................................................................................
+
+// concrete model .....................................................................................................
+
+export const SharedSecretModel = mongoose.model(
+    'SharedSecret',
+    SharedSecretSchema) as ISharedSecretModel;

--- a/backend/typescript/models/sharedSecret.model.ts
+++ b/backend/typescript/models/sharedSecret.model.ts
@@ -47,7 +47,10 @@ export interface ISharedSecretModel extends mongoose.Model<ISharedSecret> {
 // instance methods ...................................................................................................
 
 SharedSecretSchema.method('matchesValue', function (candidateValue:String) {
-    return bcrypt.compareSync(candidateValue, this.value);
+    if (candidateValue && this.value) {
+        return bcrypt.compareSync(candidateValue, this.value);
+    }
+    return false;
 });
 
 // static methods .....................................................................................................

--- a/backend/typescript/models/sharedSecret.model.ts
+++ b/backend/typescript/models/sharedSecret.model.ts
@@ -17,7 +17,7 @@ const SharedSecretSchema = RAMSchema({
         type: String,
         required: [true, 'Value is required'],
         trim: true,
-        set: (value) => {
+        set: (value:String) => {
             if (value) {
                 const salt = bcrypt.genSaltSync(10);
                 return bcrypt.hashSync(value, salt);
@@ -37,7 +37,7 @@ const SharedSecretSchema = RAMSchema({
 export interface ISharedSecret extends IRAMObject {
     value: string;
     sharedSecretType: ISharedSecretType;
-    matchesValue(candidateValue): boolean;
+    matchesValue(candidateValue:String): boolean;
 }
 
 /* tslint:disable:no-empty-interfaces */
@@ -46,7 +46,7 @@ export interface ISharedSecretModel extends mongoose.Model<ISharedSecret> {
 
 // instance methods ...................................................................................................
 
-SharedSecretSchema.method('matchesValue', function (candidateValue) {
+SharedSecretSchema.method('matchesValue', function (candidateValue:String) {
     return bcrypt.compareSync(candidateValue, this.value);
 });
 

--- a/backend/typescript/models/sharedSecretType.model.ts
+++ b/backend/typescript/models/sharedSecretType.model.ts
@@ -1,0 +1,73 @@
+import * as mongoose from 'mongoose';
+import {ICodeDecode, CodeDecodeSchema} from './base';
+
+// enums, utilities, helpers ..........................................................................................
+
+// schema .............................................................................................................
+
+const SharedSecretTypeSchema = CodeDecodeSchema({
+    domain: {
+        type: String,
+        required: [true, 'Domain is required'],
+        trim: true
+    }
+});
+
+// interfaces .........................................................................................................
+
+export interface ISharedSecretType extends ICodeDecode {
+    domain: string;
+}
+
+export interface ISharedSecretTypeModel extends mongoose.Model<ISharedSecretType> {
+    findByCodeIgnoringDateRange: (id:String) => mongoose.Promise<ISharedSecretType>;
+    findByCodeInDateRange: (id:String) => mongoose.Promise<ISharedSecretType>;
+    listIgnoringDateRange: () => mongoose.Promise<ISharedSecretType[]>;
+    listInDateRange: () => mongoose.Promise<ISharedSecretType[]>;
+}
+
+// instance methods ...................................................................................................
+
+// static methods .....................................................................................................
+
+SharedSecretTypeSchema.static('findByCodeIgnoringDateRange', (code:String) => {
+    return this.SharedSecretTypeModel
+        .findOne({
+            code: code
+        })
+        .exec();
+});
+
+SharedSecretTypeSchema.static('findByCodeInDateRange', (code:String) => {
+    return this.SharedSecretTypeModel
+        .findOne({
+            code: code,
+            startDate: {$lte: new Date()},
+            $or: [{endDate: null}, {endDate: {$gt: new Date()}}]
+        })
+        .exec();
+});
+
+SharedSecretTypeSchema.static('listIgnoringDateRange', () => {
+    return this.SharedSecretTypeModel
+        .find({
+        })
+        .sort({name: 1})
+        .exec();
+});
+
+SharedSecretTypeSchema.static('listInDateRange', () => {
+    return this.SharedSecretTypeModel
+        .find({
+            startDate: {$lte: new Date()},
+            $or: [{endDate: null}, {endDate: {$gt: new Date()}}]
+        })
+        .sort({name: 1})
+        .exec();
+});
+
+// concrete model .....................................................................................................
+
+export const SharedSecretTypeModel = mongoose.model(
+    'SharedSecretType',
+    SharedSecretTypeSchema) as ISharedSecretTypeModel;

--- a/backend/typescript/models/sharedSecretType.model.ts
+++ b/backend/typescript/models/sharedSecretType.model.ts
@@ -20,10 +20,10 @@ export interface ISharedSecretType extends ICodeDecode {
 }
 
 export interface ISharedSecretTypeModel extends mongoose.Model<ISharedSecretType> {
-    findByCodeIgnoringDateRange: (id:String) => mongoose.Promise<ISharedSecretType>;
-    findByCodeInDateRange: (id:String) => mongoose.Promise<ISharedSecretType>;
+    findByCodeIgnoringDateRange: (code:String) => mongoose.Promise<ISharedSecretType>;
+    findByCodeInDateRange: (code:String, date:Date) => mongoose.Promise<ISharedSecretType>;
     listIgnoringDateRange: () => mongoose.Promise<ISharedSecretType[]>;
-    listInDateRange: () => mongoose.Promise<ISharedSecretType[]>;
+    listInDateRange: (date:Date) => mongoose.Promise<ISharedSecretType[]>;
 }
 
 // instance methods ...................................................................................................
@@ -38,12 +38,12 @@ SharedSecretTypeSchema.static('findByCodeIgnoringDateRange', (code:String) => {
         .exec();
 });
 
-SharedSecretTypeSchema.static('findByCodeInDateRange', (code:String) => {
+SharedSecretTypeSchema.static('findByCodeInDateRange', (code:String, date:Date) => {
     return this.SharedSecretTypeModel
         .findOne({
             code: code,
-            startDate: {$lte: new Date()},
-            $or: [{endDate: null}, {endDate: {$gt: new Date()}}]
+            startDate: {$lte: date},
+            $or: [{endDate: null}, {endDate: {$gte: date}}]
         })
         .exec();
 });
@@ -56,11 +56,11 @@ SharedSecretTypeSchema.static('listIgnoringDateRange', () => {
         .exec();
 });
 
-SharedSecretTypeSchema.static('listInDateRange', () => {
+SharedSecretTypeSchema.static('listInDateRange', (date:Date) => {
     return this.SharedSecretTypeModel
         .find({
-            startDate: {$lte: new Date()},
-            $or: [{endDate: null}, {endDate: {$gt: new Date()}}]
+            startDate: {$lte: date},
+            $or: [{endDate: null}, {endDate: {$gte: date}}]
         })
         .sort({name: 1})
         .exec();

--- a/backend/typescript/seeding/seed.ts
+++ b/backend/typescript/seeding/seed.ts
@@ -5,8 +5,18 @@ import {
     IRelationshipAttributeName,
     RelationshipAttributeNameModel,
     RelationshipAttributeNameDomain} from '../models/relationshipAttributeName.model';
-import {IRelationshipAttributeNameUsage, RelationshipAttributeNameUsageModel} from '../models/relationshipAttributeNameUsage.model';
-import {IRelationshipType, RelationshipTypeModel} from '../models/relationshipType.model';
+
+import {
+    IRelationshipAttributeNameUsage,
+    RelationshipAttributeNameUsageModel} from '../models/relationshipAttributeNameUsage.model';
+
+import {
+    IRelationshipType,
+    RelationshipTypeModel} from '../models/relationshipType.model';
+
+import {
+    ISharedSecretType,
+    SharedSecretTypeModel} from '../models/sharedSecretType.model';
 
 const now = new Date();
 
@@ -79,6 +89,19 @@ class Seeder {
         }
     }
 
+    public static async createSharedSecretTypeModel(values:ISharedSecretType) {
+        const code = values.code;
+        const existingModel = await SharedSecretTypeModel.findByCodeIgnoringDateRange(code);
+        if (existingModel === null) {
+            console.log('-', code);
+            const model = await SharedSecretTypeModel.create(values);
+            return model;
+        } else {
+            console.log('-', code, ' ... skipped');
+            return existingModel;
+        }
+    }
+
 }
 
 // load reference data ................................................................................................
@@ -86,7 +109,7 @@ class Seeder {
 /* tslint:disable:max-func-body-length */
 const loadReferenceData = async () => {
 
-    // relationship attribute names
+    // relationship attribute names ...................................................................................
 
     console.log('\nInserting Relationship Attribute Names:');
 
@@ -109,7 +132,7 @@ const loadReferenceData = async () => {
         permittedValues: ['Permanent', 'Contractor', 'Casual']
     } as IRelationshipAttributeName);
 
-    // relationship types
+    // relationship types .............................................................................................
 
     console.log('\nInserting Relationship Types:');
 
@@ -227,6 +250,18 @@ const loadReferenceData = async () => {
         longDecodeText: 'Employment Agents – employment',
         startDate: now
     } as IRelationshipType, null);
+
+    // shared secret types ............................................................................................
+
+    console.log('\nInserting Shared Secret Types:');
+
+    await Seeder.createSharedSecretTypeModel({
+        code: 'DATE_OF_BIRTH',
+        shortDecodeText: 'Date of Birth',
+        longDecodeText: 'Date of Birth',
+        startDate: now,
+        domain: 'DEFAULT'
+    } as ISharedSecretType);
 
 };
 

--- a/backend/typescript/tests/identity.model.spec.ts
+++ b/backend/typescript/tests/identity.model.spec.ts
@@ -2,7 +2,10 @@ import {connectDisconnectMongo, dropMongo} from './helpers';
 import {
     IIdentity,
     IdentityModel,
-    IdentityType} from '../models/identity.model';
+    IdentityType,
+    IdentityInvitationCodeStatus,
+    IdentityPublicIdentifierScheme,
+    IdentityLinkIdScheme} from '../models/identity.model';
 import {
     IName,
     NameModel} from '../models/name.model';
@@ -40,9 +43,6 @@ describe('RAM Identity', () => {
                 idValue: 'uuid_1',
                 identityType: IdentityType.LinkId.name,
                 defaultInd: false,
-                token: 'token_1',
-                scheme: 'scheme_1',
-                consumer: 'consumer_1',
                 profile: profile1
             });
 
@@ -66,23 +66,17 @@ describe('RAM Identity', () => {
         }
     });
 
-    it('inserts with valid values', async (done) => {
+    it('inserts base with valid values', async (done) => {
         try {
 
             const idValue = 'uuid_x';
             const type = IdentityType.LinkId;
             const defaultInd = false;
-            const token = 'token_x';
-            const scheme = 'scheme_x';
-            const consumer = 'consumer_x';
 
             const instance = await IdentityModel.create({
                 idValue: idValue,
                 identityType: type.name,
                 defaultInd: defaultInd,
-                token: token,
-                scheme: scheme,
-                consumer: consumer,
                 profile: profile1
             });
 
@@ -90,8 +84,6 @@ describe('RAM Identity', () => {
             expect(instance.id).not.toBeNull();
             expect(instance.idValue).not.toBeNull();
             expect(instance.identityType).not.toBeNull();
-            expect(instance.scheme).not.toBeNull();
-            expect(instance.consumer).not.toBeNull();
             expect(instance.profile).not.toBeNull();
             expect(instance.profile.name).not.toBeNull();
 
@@ -101,11 +93,144 @@ describe('RAM Identity', () => {
             expect(retrievedInstance.identityType).toBe(type.name);
             expect(retrievedInstance.identityTypeEnum()).toBe(type);
             expect(retrievedInstance.defaultInd).toBe(defaultInd);
-            expect(retrievedInstance.token).toBe(token);
-            expect(retrievedInstance.scheme).toBe(scheme);
-            expect(retrievedInstance.consumer).toBe(consumer);
             expect(retrievedInstance.profile.id).toBe(profile1.id);
             expect(retrievedInstance.profile.name.id).toBe(name1.id);
+
+            done();
+
+        } catch (e) {
+            fail('Because ' + e);
+            done();
+        }
+    });
+
+    it('inserts agency provided token with valid values', async (done) => {
+        try {
+
+            const idValue = 'uuid_x';
+            const type = IdentityType.AgencyProvidedToken;
+            const defaultInd = false;
+            const agencyToken = 'agency_token_x';
+
+            const instance = await IdentityModel.create({
+                idValue: idValue,
+                identityType: type.name,
+                defaultInd: defaultInd,
+                agencyToken: agencyToken,
+                profile: profile1
+            });
+
+            const retrievedInstance = await IdentityModel.findByIdValueAndType(idValue, type);
+            expect(retrievedInstance).not.toBeNull();
+            expect(retrievedInstance.id).toBe(instance.id);
+            expect(retrievedInstance.identityType).toBe(type.name);
+            expect(retrievedInstance.identityTypeEnum()).toBe(type);
+            expect(retrievedInstance.agencyToken).toBe(agencyToken);
+
+            done();
+
+        } catch (e) {
+            fail('Because ' + e);
+            done();
+        }
+    });
+
+    it('inserts invitation code with valid values', async (done) => {
+        try {
+
+            const idValue = 'uuid_invitation_code';
+            const type = IdentityType.InvitationCode;
+            const defaultInd = false;
+            const status = IdentityInvitationCodeStatus.Claimed;
+            const expiryTimestamp = new Date(2055, 1, 1);
+            const claimedTimestamp = new Date(2066, 1, 1);
+            const emailAddress = 'bob@example.com';
+
+            const instance = await IdentityModel.create({
+                idValue: idValue,
+                identityType: type.name,
+                defaultInd: defaultInd,
+                invitationCodeStatus: status.name,
+                invitationCodeExpiryTimestamp: expiryTimestamp,
+                invitationCodeClaimedTimestamp: claimedTimestamp,
+                invitationCodeTemporaryEmailAddress: emailAddress,
+                profile: profile1
+            });
+
+            const retrievedInstance = await IdentityModel.findByIdValueAndType(idValue, type);
+            expect(retrievedInstance).not.toBeNull();
+            expect(retrievedInstance.id).toBe(instance.id);
+            expect(retrievedInstance.identityType).toBe(type.name);
+            expect(retrievedInstance.identityTypeEnum()).toBe(type);
+            expect(retrievedInstance.invitationCodeStatus).toBe(status.name);
+            expect(retrievedInstance.invitationCodeStatusEnum()).toBe(status);
+            expect(retrievedInstance.invitationCodeExpiryTimestamp.getTime()).toBe(expiryTimestamp.getTime());
+            expect(retrievedInstance.invitationCodeClaimedTimestamp.getTime()).toBe(claimedTimestamp.getTime());
+            expect(retrievedInstance.invitationCodeTemporaryEmailAddress).toBe(emailAddress);
+
+            done();
+
+        } catch (e) {
+            fail('Because ' + e);
+            done();
+        }
+    });
+
+    it('inserts public identifier with valid values', async (done) => {
+        try {
+
+            const idValue = 'uuid_public_identifier';
+            const type = IdentityType.PublicIdentifier;
+            const defaultInd = false;
+            const scheme = IdentityPublicIdentifierScheme.ABN;
+
+            const instance = await IdentityModel.create({
+                idValue: idValue,
+                identityType: type.name,
+                defaultInd: defaultInd,
+                publicIdentifierScheme: scheme.name,
+                profile: profile1
+            });
+
+            const retrievedInstance = await IdentityModel.findByIdValueAndType(idValue, type);
+            expect(retrievedInstance).not.toBeNull();
+            expect(retrievedInstance.id).toBe(instance.id);
+            expect(retrievedInstance.identityType).toBe(type.name);
+            expect(retrievedInstance.identityTypeEnum()).toBe(type);
+            expect(retrievedInstance.publicIdentifierScheme).toBe(scheme.name);
+            expect(retrievedInstance.publicIdentifierSchemeEnum()).toBe(scheme);
+
+            done();
+
+        } catch (e) {
+            fail('Because ' + e);
+            done();
+        }
+    });
+
+    it('inserts link id with valid values', async (done) => {
+        try {
+
+            const idValue = 'uuid_link_id';
+            const type = IdentityType.LinkId;
+            const scheme = IdentityLinkIdScheme.MyGov;
+            const defaultInd = false;
+
+            const instance = await IdentityModel.create({
+                idValue: idValue,
+                identityType: type.name,
+                defaultInd: defaultInd,
+                linkIdScheme: scheme.name,
+                profile: profile1
+            });
+
+            const retrievedInstance = await IdentityModel.findByIdValueAndType(idValue, type);
+            expect(retrievedInstance).not.toBeNull();
+            expect(retrievedInstance.id).toBe(instance.id);
+            expect(retrievedInstance.identityType).toBe(type.name);
+            expect(retrievedInstance.identityTypeEnum()).toBe(type);
+            expect(retrievedInstance.linkIdScheme).toBe(scheme.name);
+            expect(retrievedInstance.linkIdSchemeEnum()).toBe(scheme);
 
             done();
 
@@ -121,9 +246,6 @@ describe('RAM Identity', () => {
                 idValue: 'uuid_x',
                 identityType: '__BOGUS__',
                 defaultInd: false,
-                token: 'token_x',
-                scheme: 'scheme_x',
-                consumer: 'scheme_x',
                 profile: profile1
             });
             fail('should not have inserted with invalid type');
@@ -140,9 +262,6 @@ describe('RAM Identity', () => {
             await IdentityModel.create({
                 idValue: 'uuid_x',
                 defaultInd: false,
-                token: 'token_x',
-                scheme: 'scheme_x',
-                consumer: 'scheme_x',
                 profile: profile1
             });
             fail('should not have inserted with null type');
@@ -159,10 +278,7 @@ describe('RAM Identity', () => {
             await IdentityModel.create({
                 idValue: 'uuid_x',
                 identityType: IdentityType.LinkId.name,
-                defaultInd: false,
-                token: 'token_x',
-                scheme: 'scheme_x',
-                consumer: 'scheme_x'
+                defaultInd: false
             });
             fail('should not have inserted with null profile');
             done();

--- a/backend/typescript/tests/identity.model.spec.ts
+++ b/backend/typescript/tests/identity.model.spec.ts
@@ -4,12 +4,12 @@ import {
     IdentityModel,
     IdentityType} from '../models/identity.model';
 import {
+    IName,
+    NameModel} from '../models/name.model';
+import {
     IProfile,
     ProfileModel,
     ProfileProvider} from '../models/profile.model';
-import {
-    IName,
-    NameModel} from '../models/name.model';
 
 /* tslint:disable:max-func-body-length */
 describe('RAM Identity', () => {
@@ -55,7 +55,7 @@ describe('RAM Identity', () => {
 
     });
 
-    it('finds identity by id value', async (done) => {
+    it('finds by id value and type', async (done) => {
         try {
             const instance = await IdentityModel.findByIdValueAndType(identity1.idValue, IdentityType.valueOf(identity1.identityType));
             expect(instance).not.toBeNull();

--- a/backend/typescript/tests/profile.model.spec.ts
+++ b/backend/typescript/tests/profile.model.spec.ts
@@ -63,9 +63,6 @@ describe('RAM Profile', () => {
                 idValue: 'uuid_1',
                 identityType: IdentityType.LinkId.name,
                 defaultInd: false,
-                token: 'token_1',
-                scheme: 'scheme_1',
-                consumer: 'consumer_1',
                 profile: profile1
             });
 

--- a/backend/typescript/tests/relationshipAttributeName.model.spec.ts
+++ b/backend/typescript/tests/relationshipAttributeName.model.spec.ts
@@ -86,7 +86,7 @@ describe('RAM Relationship Attribute Name', () => {
 
     it('finds relationship type with inflated attributes', async (done) => {
         try {
-            const instance = await RelationshipTypeModel.findByCodeInDateRange(relationshipType1.code);
+            const instance = await RelationshipTypeModel.findByCodeInDateRange(relationshipType1.code, new Date());
             expect(instance).not.toBeNull();
             expect(instance.attributeNameUsages.length).toBe(1);
             expect(instance.attributeNameUsages[0].optionalInd).toBe(true);
@@ -101,7 +101,8 @@ describe('RAM Relationship Attribute Name', () => {
 
     it('finds in date range with no end date by code', async (done) => {
         try {
-            const instance = await RelationshipAttributeNameModel.findByCodeInDateRange(stringRelationshipAttributeNameNoEndDate.code);
+            const instance = await RelationshipAttributeNameModel.findByCodeInDateRange(
+                stringRelationshipAttributeNameNoEndDate.code, new Date());
             expect(instance).not.toBeNull();
             done();
         } catch (e) {
@@ -125,7 +126,7 @@ describe('RAM Relationship Attribute Name', () => {
     it('fails find in date range by non-existent code', async (done) => {
         try {
             const code = '__BOGUS__';
-            const instance = await RelationshipAttributeNameModel.findByCodeInDateRange(code);
+            const instance = await RelationshipAttributeNameModel.findByCodeInDateRange(code, new Date());
             expect(instance).toBeNull();
             done();
         } catch (e) {
@@ -136,7 +137,8 @@ describe('RAM Relationship Attribute Name', () => {
 
     it('fails find not in date range by code', async (done) => {
         try {
-            const instance = await RelationshipAttributeNameModel.findByCodeInDateRange(stringRelationshipAttributeNameExpiredEndDate.code);
+            const instance = await RelationshipAttributeNameModel.findByCodeInDateRange(
+                stringRelationshipAttributeNameExpiredEndDate.code, new Date());
             expect(instance).toBeNull();
             done();
         } catch (e) {
@@ -148,7 +150,7 @@ describe('RAM Relationship Attribute Name', () => {
     it('finds with permitted values by code', async (done) => {
         try {
             const instance = await RelationshipAttributeNameModel.findByCodeInDateRange(
-                singleSelectRelationshipAttributeNameNoEndDate.code);
+                singleSelectRelationshipAttributeNameNoEndDate.code, new Date());
             expect(instance).not.toBeNull();
             expect(instance.permittedValues).not.toBeNull();
             expect(instance.permittedValues.length).toBe(singleSelectRelationshipAttributeNameNoEndDate.permittedValues.length);
@@ -174,7 +176,7 @@ describe('RAM Relationship Attribute Name', () => {
 
     it('lists in date range', async (done) => {
         try {
-            const instances = await RelationshipAttributeNameModel.listInDateRange();
+            const instances = await RelationshipAttributeNameModel.listInDateRange(new Date());
             expect(instances).not.toBeNull();
             expect(instances.length).toBe(3);
             instances.forEach((instance) => {

--- a/backend/typescript/tests/relationshipType.model.spec.ts
+++ b/backend/typescript/tests/relationshipType.model.spec.ts
@@ -50,7 +50,7 @@ describe('RAM Relationship Type', () => {
 
     it('finds in date range with no end date by code', async (done) => {
         try {
-            const instance = await RelationshipTypeModel.findByCodeInDateRange(relationshipTypeNoEndDate.code);
+            const instance = await RelationshipTypeModel.findByCodeInDateRange(relationshipTypeNoEndDate.code, new Date());
             expect(instance).not.toBeNull();
             done();
         } catch (e) {
@@ -61,7 +61,7 @@ describe('RAM Relationship Type', () => {
 
     it('finds in date range with future end date by code', async (done) => {
         try {
-            const instance = await RelationshipTypeModel.findByCodeInDateRange(relationshipTypeFutureEndDate.code);
+            const instance = await RelationshipTypeModel.findByCodeInDateRange(relationshipTypeFutureEndDate.code, new Date());
             expect(instance).not.toBeNull();
             done();
         } catch (e) {
@@ -84,7 +84,7 @@ describe('RAM Relationship Type', () => {
     it('fails find in date range by non-existent code', async (done) => {
         try {
             const code = '__BOGUS__';
-            const instance = await RelationshipTypeModel.findByCodeInDateRange(code);
+            const instance = await RelationshipTypeModel.findByCodeInDateRange(code, new Date());
             expect(instance).toBeNull();
             done();
         } catch (e) {
@@ -95,7 +95,7 @@ describe('RAM Relationship Type', () => {
 
     it('fails find not in date range by code', async (done) => {
         try {
-            const instance = await RelationshipTypeModel.findByCodeInDateRange(relationshipTypeExpiredEndDate.code);
+            const instance = await RelationshipTypeModel.findByCodeInDateRange(relationshipTypeExpiredEndDate.code, new Date());
             expect(instance).toBeNull();
             done();
         } catch (e) {
@@ -118,7 +118,7 @@ describe('RAM Relationship Type', () => {
 
     it('lists in date range', async (done) => {
         try {
-            const instances = await RelationshipTypeModel.listInDateRange();
+            const instances = await RelationshipTypeModel.listInDateRange(new Date());
             expect(instances).not.toBeNull();
             expect(instances.length).toBe(2);
             instances.forEach((instance) => {
@@ -148,7 +148,7 @@ describe('RAM Relationship Type', () => {
             expect(instance.id).not.toBeNull();
             expect(instance.code).not.toBeNull();
 
-            const retrievedInstance = await RelationshipTypeModel.findByCodeInDateRange(instance.code);
+            const retrievedInstance = await RelationshipTypeModel.findByCodeInDateRange(instance.code, new Date());
             expect(retrievedInstance).not.toBeNull();
             expect(retrievedInstance.id).toBe(instance.id);
 

--- a/backend/typescript/tests/sharedSecret.model.spec.ts
+++ b/backend/typescript/tests/sharedSecret.model.spec.ts
@@ -84,9 +84,6 @@ describe('RAM Shared Secret', () => {
                 idValue: 'uuid_1',
                 identityType: IdentityType.LinkId.name,
                 defaultInd: false,
-                token: 'token_1',
-                scheme: 'scheme_1',
-                consumer: 'consumer_1',
                 profile: profile1
             });
 

--- a/backend/typescript/tests/sharedSecret.model.spec.ts
+++ b/backend/typescript/tests/sharedSecret.model.spec.ts
@@ -151,4 +151,24 @@ describe('RAM Shared Secret', () => {
         }
     });
 
+    it('matches value', async (done) => {
+        try {
+            expect(sharedSecretNoEndDate.matchesValue(sharedSecretValue1)).toBe(true);
+            done();
+        } catch (e) {
+            fail('Because ' + e);
+            done();
+        }
+    });
+
+    it('does not match null value', async (done) => {
+        try {
+            expect(sharedSecretNoEndDate.matchesValue(null)).toBe(false);
+            done();
+        } catch (e) {
+            fail('Because ' + e);
+            done();
+        }
+    });
+
 });

--- a/backend/typescript/tests/sharedSecret.model.spec.ts
+++ b/backend/typescript/tests/sharedSecret.model.spec.ts
@@ -18,7 +18,7 @@ import {
     IdentityType} from '../models/identity.model';
 
 /* tslint:disable:max-func-body-length */
-describe('RAM Shared Secret Type', () => {
+describe('RAM Shared Secret', () => {
 
     connectDisconnectMongo();
     dropMongo();

--- a/backend/typescript/tests/sharedSecret.model.spec.ts
+++ b/backend/typescript/tests/sharedSecret.model.spec.ts
@@ -1,0 +1,117 @@
+import {connectDisconnectMongo, dropMongo} from './helpers';
+import {
+    ISharedSecret,
+    SharedSecretModel} from '../models/sharedSecret.model';
+import {
+    ISharedSecretType,
+    SharedSecretTypeModel} from '../models/sharedSecretType.model';
+import {
+    IName,
+    NameModel} from '../models/name.model';
+import {
+    IProfile,
+    ProfileModel,
+    ProfileProvider} from '../models/profile.model';
+import {
+    IIdentity,
+    IdentityModel,
+    IdentityType} from '../models/identity.model';
+
+/* tslint:disable:max-func-body-length */
+describe('RAM Shared Secret Type', () => {
+
+    connectDisconnectMongo();
+    dropMongo();
+
+    let sharedSecretTypeNoEndDate: ISharedSecretType;
+    let sharedSecretTypeFutureEndDate: ISharedSecretType;
+    let sharedSecretTypeExpiredEndDate: ISharedSecretType;
+
+    let sharedSecretNoEndDate: ISharedSecret;
+    let name1: IName;
+    let profile1: IProfile;
+    let identity1: IIdentity;
+
+    beforeEach(async (done) => {
+
+        try {
+
+            sharedSecretTypeNoEndDate = await SharedSecretTypeModel.create({
+                code: 'SHARED_SECRET_TYPE_1',
+                shortDecodeText: 'Shared Secret',
+                longDecodeText: 'Shared Secret',
+                startDate: new Date(),
+                domain: 'domain'
+            });
+
+            sharedSecretTypeFutureEndDate = await SharedSecretTypeModel.create({
+                code: 'SHARED_SECRET_TYPE_2',
+                shortDecodeText: 'Shared Secret',
+                longDecodeText: 'Shared Secret',
+                startDate: new Date(),
+                endDate: new Date(2099, 1, 1),
+                domain: 'domain'
+            });
+
+            sharedSecretTypeExpiredEndDate = await SharedSecretTypeModel.create({
+                code: 'SHARED_SECRET_TYPE_3',
+                shortDecodeText: 'Shared Secret',
+                longDecodeText: 'Shared Secret',
+                startDate: new Date(2016, 1, 1),
+                endDate: new Date(2016, 1, 2),
+                domain: 'domain'
+            });
+
+            sharedSecretNoEndDate = await SharedSecretModel.create({
+                value: 'secret_value_1',
+                sharedSecretType: sharedSecretTypeNoEndDate
+            });
+
+            name1 = await NameModel.create({
+                givenName: 'John',
+                familyName: 'Smith',
+                unstructuredName: 'John Smith'
+            });
+
+            profile1 = await ProfileModel.create({
+                provider: ProfileProvider.MyGov.name,
+                name: name1,
+                sharedSecrets: [sharedSecretNoEndDate]
+            });
+
+            identity1 = await IdentityModel.create({
+                idValue: 'uuid_1',
+                identityType: IdentityType.LinkId.name,
+                defaultInd: false,
+                token: 'token_1',
+                scheme: 'scheme_1',
+                consumer: 'consumer_1',
+                profile: profile1
+            });
+
+            done();
+
+        } catch (e) {
+            fail('Because ' + e);
+            done();
+        }
+
+    });
+
+    it('finds identity includes profile and shared secrets', async (done) => {
+        try {
+            const instance = await IdentityModel.findByIdValueAndType(identity1.idValue, IdentityType.valueOf(identity1.identityType));
+            expect(instance).not.toBeNull();
+            expect(instance.id).toBe(identity1.id);
+            expect(instance.profile.id).toBe(profile1.id);
+            expect(instance.profile.sharedSecrets.length).toBe(1);
+            expect(instance.profile.sharedSecrets[0].value).toBe(sharedSecretNoEndDate.value);
+            expect(instance.profile.sharedSecrets[0].sharedSecretType.code).toBe(sharedSecretNoEndDate.sharedSecretType.code);
+            done();
+        } catch (e) {
+            fail('Because ' + e);
+            done();
+        }
+    });
+
+});

--- a/backend/typescript/tests/sharedSecretType.model.spec.ts
+++ b/backend/typescript/tests/sharedSecretType.model.spec.ts
@@ -54,7 +54,7 @@ describe('RAM Shared Secret Type', () => {
 
     it('finds in date range with no end date by code', async (done) => {
         try {
-            const instance = await SharedSecretTypeModel.findByCodeInDateRange(sharedSecretTypeNoEndDate.code);
+            const instance = await SharedSecretTypeModel.findByCodeInDateRange(sharedSecretTypeNoEndDate.code, new Date());
             expect(instance).not.toBeNull();
             done();
         } catch (e) {
@@ -78,7 +78,7 @@ describe('RAM Shared Secret Type', () => {
     it('fails find in date range by non-existent code', async (done) => {
         try {
             const code = '__BOGUS__';
-            const instance = await SharedSecretTypeModel.findByCodeInDateRange(code);
+            const instance = await SharedSecretTypeModel.findByCodeInDateRange(code, new Date());
             expect(instance).toBeNull();
             done();
         } catch (e) {
@@ -89,7 +89,7 @@ describe('RAM Shared Secret Type', () => {
 
     it('fails find not in date range by code', async (done) => {
         try {
-            const instance = await SharedSecretTypeModel.findByCodeInDateRange(sharedSecretTypeExpiredEndDate.code);
+            const instance = await SharedSecretTypeModel.findByCodeInDateRange(sharedSecretTypeExpiredEndDate.code, new Date());
             expect(instance).toBeNull();
             done();
         } catch (e) {
@@ -112,7 +112,7 @@ describe('RAM Shared Secret Type', () => {
 
     it('lists in date range', async (done) => {
         try {
-            const instances = await SharedSecretTypeModel.listInDateRange();
+            const instances = await SharedSecretTypeModel.listInDateRange(new Date());
             expect(instances).not.toBeNull();
             expect(instances.length).toBe(2);
             instances.forEach((instance) => {

--- a/backend/typescript/tests/sharedSecretType.model.spec.ts
+++ b/backend/typescript/tests/sharedSecretType.model.spec.ts
@@ -1,0 +1,214 @@
+import {connectDisconnectMongo, dropMongo} from './helpers';
+import {
+    ISharedSecretType,
+    SharedSecretTypeModel} from '../models/sharedSecretType.model';
+
+/* tslint:disable:max-func-body-length */
+describe('RAM Shared Secret Type', () => {
+
+    connectDisconnectMongo();
+    dropMongo();
+
+    let sharedSecretTypeNoEndDate: ISharedSecretType;
+    let sharedSecretTypeFutureEndDate: ISharedSecretType;
+    let sharedSecretTypeExpiredEndDate: ISharedSecretType;
+
+    beforeEach(async (done) => {
+
+        try {
+
+            sharedSecretTypeNoEndDate = await SharedSecretTypeModel.create({
+                code: 'SHARED_SECRET_TYPE_1',
+                shortDecodeText: 'Shared Secret',
+                longDecodeText: 'Shared Secret',
+                startDate: new Date(),
+                domain: 'domain'
+            });
+
+            sharedSecretTypeFutureEndDate = await SharedSecretTypeModel.create({
+                code: 'SHARED_SECRET_TYPE_2',
+                shortDecodeText: 'Shared Secret',
+                longDecodeText: 'Shared Secret',
+                startDate: new Date(),
+                endDate: new Date(2099, 1, 1),
+                domain: 'domain'
+            });
+
+            sharedSecretTypeExpiredEndDate = await SharedSecretTypeModel.create({
+                code: 'SHARED_SECRET_TYPE_3',
+                shortDecodeText: 'Shared Secret',
+                longDecodeText: 'Shared Secret',
+                startDate: new Date(2016, 1, 1),
+                endDate: new Date(2016, 1, 2),
+                domain: 'domain'
+            });
+
+            done();
+
+        } catch (e) {
+            fail('Because ' + e);
+            done();
+        }
+
+    });
+
+    it('finds in date range with no end date by code', async (done) => {
+        try {
+            const instance = await SharedSecretTypeModel.findByCodeInDateRange(sharedSecretTypeNoEndDate.code);
+            expect(instance).not.toBeNull();
+            done();
+        } catch (e) {
+            fail('Because ' + e);
+            done();
+        }
+    });
+
+    it('finds in date range or invalid by code', async (done) => {
+        try {
+            const instance = await SharedSecretTypeModel.findByCodeIgnoringDateRange(
+                sharedSecretTypeNoEndDate.code);
+            expect(instance).not.toBeNull();
+            done();
+        } catch (e) {
+            fail('Because ' + e);
+            done();
+        }
+    });
+
+    it('fails find in date range by non-existent code', async (done) => {
+        try {
+            const code = '__BOGUS__';
+            const instance = await SharedSecretTypeModel.findByCodeInDateRange(code);
+            expect(instance).toBeNull();
+            done();
+        } catch (e) {
+            fail('Because ' + e);
+            done();
+        }
+    });
+
+    it('fails find not in date range by code', async (done) => {
+        try {
+            const instance = await SharedSecretTypeModel.findByCodeInDateRange(sharedSecretTypeExpiredEndDate.code);
+            expect(instance).toBeNull();
+            done();
+        } catch (e) {
+            fail('Because ' + e);
+            done();
+        }
+    });
+
+    it('lists ignoring date range', async (done) => {
+        try {
+            const instances = await SharedSecretTypeModel.listIgnoringDateRange();
+            expect(instances).not.toBeNull();
+            expect(instances.length).toBe(3);
+            done();
+        } catch (e) {
+            fail('Because ' + e);
+            done();
+        }
+    });
+
+    it('lists in date range', async (done) => {
+        try {
+            const instances = await SharedSecretTypeModel.listInDateRange();
+            expect(instances).not.toBeNull();
+            expect(instances.length).toBe(2);
+            instances.forEach((instance) => {
+                expect(instance.startDate.valueOf()).toBeLessThan(new Date().valueOf());
+                if (instance.endDate) {
+                    expect(instance.endDate.valueOf()).toBeGreaterThan(new Date().valueOf());
+                }
+            });
+            done();
+        } catch (e) {
+            fail('Because ' + e);
+            done();
+        }
+    });
+
+    it('fails insert with null code', async (done) => {
+        try {
+            await SharedSecretTypeModel.create({
+                shortDecodeText: 'Some short decode text',
+                longDecodeText: 'Some long decode text',
+                startDate: new Date(),
+                domain: 'domain'
+            });
+            fail('should not have inserted with null code');
+            done();
+        } catch (e) {
+            expect(e.name).toBe('ValidationError');
+            expect(e.errors.code).not.toBeNull();
+            done();
+        }
+    });
+
+    it('fails insert with empty code', async (done) => {
+        try {
+            await SharedSecretTypeModel.create({
+                shortDecodeText: 'Some short decode text',
+                longDecodeText: 'Some long decode text',
+                startDate: new Date(),
+                domain: 'domain'
+            });
+            fail('should not have inserted with empty code');
+            done();
+        } catch (e) {
+            expect(e.name).toBe('ValidationError');
+            expect(e.errors.code).not.toBeNull();
+            done();
+        }
+    });
+
+    it('fails insert with null domain', async (done) => {
+        try {
+            await SharedSecretTypeModel.create({
+                code: 'SHARED_SECRET_TYPE_X',
+                shortDecodeText: 'Some short decode text',
+                longDecodeText: 'Some long decode text',
+                startDate: new Date()
+            });
+            fail('should not have inserted with null domain');
+            done();
+        } catch (e) {
+            expect(e.name).toBe('ValidationError');
+            expect(e.errors.domain).not.toBeNull();
+            done();
+        }
+    });
+
+    it('fails insert with duplicate code', async (done) => {
+        try {
+
+            const code = 'CODE_DUPLICATE';
+
+            await SharedSecretTypeModel.create({
+                code: code,
+                shortDecodeText: 'Some short decode text',
+                longDecodeText: 'Some long decode text',
+                startDate: new Date(),
+                domain: 'domain',
+            });
+
+            await SharedSecretTypeModel.create({
+                code: code,
+                shortDecodeText: 'Some short decode text',
+                longDecodeText: 'Some long decode text',
+                startDate: new Date(),
+                domain: 'domain'
+            });
+
+            fail('should not have inserted with duplicate code');
+            done();
+
+        } catch (e) {
+            expect(e.name).toBe('ValidationError');
+            expect(e.errors.code).not.toBeNull();
+            expect(e.errors.code.message).toContain('unique');
+            done();
+        }
+    });
+
+});

--- a/backend/typings.json
+++ b/backend/typings.json
@@ -1,5 +1,6 @@
 {
   "globalDependencies": {
+    "bcrypt": "registry:dt/bcrypt#0.0.0+20160316155526",
     "body-parser": "registry:dt/body-parser#0.0.0+20160317120654",
     "cookie-parser": "registry:dt/cookie-parser#1.3.4+20160316155526",
     "express": "registry:dt/express#4.0.0+20160317120654",


### PR DESCRIPTION
Adds these new entities to the model and hooked up to identity and profile. These have been coded from a modelling perspective only. No real business logic have been applied to these yet. If required, they will come later as a separate pull request.

Specifically, no implementation or consideration of:
- what's conditionally mandatory
- what's valid based on the specialised Identity types
- how the Identity, Profile, Name, Shared Secret will be used
