### PR TITLE
Added Relationship.searchDistinctSubjectsBySubjectOrDelegateIdentity; Added model tests

### DIFF
--- a/backend/typescript/models/relationship.model.ts
+++ b/backend/typescript/models/relationship.model.ts
@@ -332,6 +332,8 @@ RelationshipSchema.static('search', (subjectIdentityIdValue:string, delegateIden
 });
 
 /* tslint:disable:max-func-body-length */
+// todo need to optional filters (term, party type, relationship type, status)
+// todo need to add sorting
 RelationshipSchema.static('searchDistinctSubjectsByDelegate', (identityIdValue:string, page:number, reqPageSize:number) => {
     return new Promise<SearchResult<IParty>>(async(resolve, reject) => {
         const pageSize:number = reqPageSize ? Math.min(reqPageSize, MAX_PAGE_SIZE) : MAX_PAGE_SIZE;

--- a/backend/typescript/models/relationship.model.ts
+++ b/backend/typescript/models/relationship.model.ts
@@ -133,7 +133,7 @@ export interface IRelationshipModel extends mongoose.Model<IRelationship> {
     findPendingByInvitationCodeInDateRange:(invitationCode:string, date:Date) => Promise<IRelationship>;
     search:(subjectIdentityIdValue:string, delegateIdentityIdValue:string, page:number, pageSize:number)
         => Promise<SearchResult<IRelationship>>;
-    searchDistinctSubjectsByDelegate:(identityIdValue:string, page:number, pageSize:number)
+    searchDistinctSubjectsBySubjectOrDelegateIdentity:(identityIdValue:string, page:number, pageSize:number)
         => Promise<SearchResult<IParty>>;
 }
 
@@ -331,10 +331,10 @@ RelationshipSchema.static('search', (subjectIdentityIdValue:string, delegateIden
     });
 });
 
-/* tslint:disable:max-func-body-length */
 // todo need to optional filters (term, party type, relationship type, status)
 // todo need to add sorting
-RelationshipSchema.static('searchDistinctSubjectsByDelegate', (identityIdValue:string, page:number, reqPageSize:number) => {
+/* tslint:disable:max-func-body-length */
+RelationshipSchema.static('searchDistinctSubjectsBySubjectOrDelegateIdentity', (identityIdValue:string, page:number, reqPageSize:number) => {
     return new Promise<SearchResult<IParty>>(async(resolve, reject) => {
         const pageSize:number = reqPageSize ? Math.min(reqPageSize, MAX_PAGE_SIZE) : MAX_PAGE_SIZE;
         try {

--- a/backend/typescript/tests/relationship.model.spec.ts
+++ b/backend/typescript/tests/relationship.model.spec.ts
@@ -32,12 +32,14 @@ describe('RAM Relationship', () => {
     let relationshipTypeCustom:IRelationshipType;
 
     let subjectNickName1:IName;
+    let subjectProfile1:IProfile;
     let subjectParty1:IParty;
 
     let delegateNickName1:IName;
     let delegateProfile1:IProfile;
     let delegateParty1:IParty;
 
+    let subjectIdentity1:IIdentity;
     let delegateIdentity1:IIdentity;
     let relationship1:IRelationship;
 
@@ -60,6 +62,11 @@ describe('RAM Relationship', () => {
                         familyName: 'Subject 1'
                     });
 
+                    subjectProfile1 = await ProfileModel.create({
+                        provider: ProfileProvider.MyGov.name,
+                        name: subjectNickName1
+                    });
+
                     subjectParty1 = await PartyModel.create({
                         partyType: PartyType.Individual.name
                     });
@@ -76,6 +83,15 @@ describe('RAM Relationship', () => {
 
                     delegateParty1 = await PartyModel.create({
                         partyType: PartyType.Individual.name
+                    });
+
+                    subjectIdentity1 = await IdentityModel.create({
+                        rawIdValue: 'uuid_1',
+                        identityType: IdentityType.LinkId.name,
+                        defaultInd: true,
+                        linkIdScheme: IdentityLinkIdScheme.MyGov.name,
+                        profile: subjectProfile1,
+                        party: subjectParty1
                     });
 
                     delegateIdentity1 = await IdentityModel.create({
@@ -327,6 +343,68 @@ describe('RAM Relationship', () => {
             done();
 
         } catch (e) {
+            done();
+        }
+    });
+
+    it('searches with subject', async (done) => {
+        try {
+
+            const relationships = await RelationshipModel.search(subjectIdentity1.idValue, null, 1, 10);
+            expect(relationships.totalCount).toBe(1);
+            expect(relationships.list.length).toBe(1);
+            expect(relationships.list[0].id).toBe(relationship1.id);
+
+            done();
+
+        } catch (e) {
+            fail('Because ' + e);
+            done();
+        }
+    });
+
+    it('fails searches with non-existent subject', async (done) => {
+        try {
+
+            const relationships = await RelationshipModel.search('__BOGUS__', null, 1, 10);
+            expect(relationships.totalCount).toBe(0);
+            expect(relationships.list.length).toBe(0);
+
+            done();
+
+        } catch (e) {
+            fail('Because ' + e);
+            done();
+        }
+    });
+
+    it('searches with delegate', async (done) => {
+        try {
+
+            const relationships = await RelationshipModel.search(null, delegateIdentity1.idValue, 1, 10);
+            expect(relationships.totalCount).toBe(1);
+            expect(relationships.list.length).toBe(1);
+            expect(relationships.list[0].id).toBe(relationship1.id);
+
+            done();
+
+        } catch (e) {
+            fail('Because ' + e);
+            done();
+        }
+    });
+
+    it('fails searches with non-existent delegate', async (done) => {
+        try {
+
+            const relationships = await RelationshipModel.search(null, '__BOGUS__', 1, 10);
+            expect(relationships.totalCount).toBe(0);
+            expect(relationships.list.length).toBe(0);
+
+            done();
+
+        } catch (e) {
+            fail('Because ' + e);
             done();
         }
     });

--- a/backend/typescript/tests/relationship.model.spec.ts
+++ b/backend/typescript/tests/relationship.model.spec.ts
@@ -434,7 +434,7 @@ describe('RAM Relationship', () => {
                 status: RelationshipStatus.Pending.name
             });
 
-            const parties = await RelationshipModel.searchDistinctSubjectsByDelegate(delegateIdentity1.idValue, 1, 10);
+            const parties = await RelationshipModel.searchDistinctSubjectsBySubjectOrDelegateIdentity(delegateIdentity1.idValue, 1, 10);
             expect(parties.totalCount).toBe(2);
             expect(parties.list.length).toBe(2);
 


### PR DESCRIPTION
Returns a paginated list of distinct subjects for relationships which have a subject or delegate matching the one supplied.

No filtering or sorting yet.