### PR TITLE
Fixed export of idValue from MongoDB to LDIF.

### DIFF
--- a/backend/typescript/seeding/ldifExporter.ts
+++ b/backend/typescript/seeding/ldifExporter.ts
@@ -46,9 +46,9 @@ export class LDIFExporter {
     public static async exportIdentity(identity: IIdentity) {
         if ((identity.party.partyType === 'INDIVIDUAL') && (identity.identityType === 'LINK_ID')) {
             await fs.appendFile(LDIFExporter.ldifFileHandle, LDIFExporter.getIdentityLDIF(identity));
-            Seeder.log(`\n[LDIFExporter] Exported identity ${identity.rawIdValue}\n`.green);
+            Seeder.log(`\n[LDIFExporter] Exported identity ${identity.idValue}\n`.green);
         } else {
-            Seeder.log(`\n[LDIFExporter] Skipped export of identity ${identity.rawIdValue}\n`.gray);
+            Seeder.log(`\n[LDIFExporter] Skipped export of identity ${identity.idValue}\n`.gray);
         }
     }
 

--- a/backend/typescript/seeding/seed.ts
+++ b/backend/typescript/seeding/seed.ts
@@ -311,7 +311,7 @@ export class Seeder {
     public static async createIdentityModel(values:IIdentity) {
         const model = await IdentityModel.create(values);
         Seeder.log(`- Identity  : ${model.idValue}`.cyan);
-        Seeder.exportIdentity(values);
+        Seeder.exportIdentity(model);
         return model;
     }
 


### PR DESCRIPTION
LDIF export was missing the idValue, meaning RAM back-end could not correlate against seeded identities in MongoDB.